### PR TITLE
Dokken/post proc

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -73,6 +73,7 @@ jobs:
           export CC=mpicc
           export HDF5_DIR="/usr/lib/x86_64-linux-gnu/hdf5/mpich/"
           pip3 install --no-cache-dir --no-binary=h5py h5py meshio
+          pip3 install matplotlib
       - name: Run demos
         run: |
           mpirun -n 2 python3 generate_team30_meshes.py --single --three

--- a/generate_team30_meshes.py
+++ b/generate_team30_meshes.py
@@ -106,7 +106,7 @@ def generate_mesh(filename: str, res: np.float64, L: np.float64, angles):
         gmsh.model.mesh.field.add("Threshold", 2)
         gmsh.model.mesh.field.setNumber(2, "IField", 1)
         gmsh.model.mesh.field.setNumber(2, "LcMin", res)
-        gmsh.model.mesh.field.setNumber(2, "LcMax", 10 * res)
+        gmsh.model.mesh.field.setNumber(2, "LcMax", 20 * res)
         gmsh.model.mesh.field.setNumber(2, "DistMin", r2)
         gmsh.model.mesh.field.setNumber(2, "DistMax", 2 * r5)
         gmsh.model.mesh.field.add("Min", 3)
@@ -150,9 +150,9 @@ if __name__ == "__main__":
         description="GMSH scripts to generate induction engines for"
         + "the TEAM 30 problem (http://www.compumag.org/jsite/images/stories/TEAM/problem30a.pdf)",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--res", default=0.0005, type=np.float64, dest="res",
+    parser.add_argument("--res", default=0.0002, type=np.float64, dest="res",
                         help="Mesh resolution")
-    parser.add_argument("--L", default=0.3, type=np.float64, dest="L",
+    parser.add_argument("--L", default=0.25, type=np.float64, dest="L",
                         help="Size of surround box with air")
     _single = parser.add_mutually_exclusive_group(required=False)
     _single.add_argument('--single', dest='single', action='store_true',

--- a/generate_team30_meshes.py
+++ b/generate_team30_meshes.py
@@ -150,7 +150,7 @@ if __name__ == "__main__":
         description="GMSH scripts to generate induction engines for"
         + "the TEAM 30 problem (http://www.compumag.org/jsite/images/stories/TEAM/problem30a.pdf)",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--res", default=0.0002, type=np.float64, dest="res",
+    parser.add_argument("--res", default=0.0004, type=np.float64, dest="res",
                         help="Mesh resolution")
     parser.add_argument("--L", default=0.25, type=np.float64, dest="L",
                         help="Size of surround box with air")

--- a/team30_A_phi.py
+++ b/team30_A_phi.py
@@ -14,7 +14,7 @@ from generate_team30_meshes import r2, r3
 mu_0 = 1.25663753e-6  # Relative permability of air
 freq = 60  # Frequency of excitation
 omega_J = 2 * np.pi * freq
-J = 3.1e6  # [A/m^2] Current density of copper winding
+J = 3.1e6 * np.sqrt(2)  # [A/m^2] Current density of copper winding
 
 _mu_r = {"Cu": 1, "Stator": 30, "Rotor": 30, "Al": 1, "Air": 1}
 _sigma = {"Rotor": 1.6e6, "Al": 3.72e7, "Stator": 0, "Cu": 0, "Air": 0}
@@ -30,6 +30,8 @@ _domains_single = {"Cu": (1, 2), "Stator": (3,), "Rotor": (4,),
                    "Al": (7,), "Air": (5, 6, 8, 9, 10)}
 # Currents on the form J_0 = (0,0, alpha*J*cos(omega*t + beta)) in domain i
 _currents_single = {1: {"alpha": 1, "beta": 0}, 2: {"alpha": -1, "beta": 0}}
+# Domain data for air gap between rotor and windings, MidAir is the tag an internal interface
+# AirGap is the domain markers for the domain
 _torque_single = {"MidAir": (11,), "restriction": "+", "AirGap": (5, 6)}
 # Three phase model domains:
 # Copper (0 degrees): 1
@@ -44,6 +46,8 @@ _torque_single = {"MidAir": (11,), "restriction": "+", "AirGap": (5, 6)}
 # Alu rotor: 11
 _domains_three = {"Cu": (1, 2, 3, 4, 5, 6), "Stator": (7,), "Rotor": (8,),
                   "Al": (10,), "Air": (9, 11, 12, 13, 14, 15, 16, 17, 18)}
+# Domain data for air gap between rotor and windings, MidAir is the tag an internal interface
+# AirGap is the domain markers for the domain
 _torque_three = {"MidAir": (19,), "restriction": "+", "AirGap": (9, 10)}
 # Currents on the form J_0 = (0,0, alpha*J*cos(omega*t + beta)) in domain i
 _currents_three = {1: {"alpha": 1, "beta": 0}, 2: {"alpha": -1, "beta": 2 * np.pi / 3},
@@ -370,7 +374,7 @@ if __name__ == "__main__":
     _three = parser.add_mutually_exclusive_group(required=False)
     _three.add_argument('--three', dest='three', action='store_true',
                         help="Solve three phase problem", default=False)
-    parser.add_argument("--T", dest='T', type=np.float64, default=0.01, help="End time of simulation")
+    parser.add_argument("--T", dest='T', type=np.float64, default=0.1, help="End time of simulation")
     parser.add_argument("--omega", dest='omegaU', type=np.float64, default=0, help="Angular speed of rotor")
     parser.add_argument("--degree", dest='degree', type=np.int32, default=1,
                         help="Degree of magnetic vector potential functions space")

--- a/team30_A_phi.py
+++ b/team30_A_phi.py
@@ -236,7 +236,8 @@ def solve_team30(single_phase: bool, T: np.float64, omega_u: np.float64, degree:
     AzV = dolfinx.Function(VQ)
 
     # Create output file
-    postproc = PostProcessing(mesh.mpi_comm(), f"results/TEAM30_{omega_u}")
+    ext = "single" if single_phase else "three"
+    postproc = PostProcessing(mesh.mpi_comm(), f"results/TEAM30_{omega_u}_{ext}")
     postproc.write_mesh(mesh)
     # postproc.write_function(sigma, 0, "sigma")
     # postproc.write_function(mu_R, 0, "mu_R")
@@ -272,7 +273,8 @@ def solve_team30(single_phase: bool, T: np.float64, omega_u: np.float64, degree:
     torque += dolfinx.Constant(mesh, 0) * _dx
     dx_gap = ufl.Measure("dx", domain=mesh, subdomain_data=ct, subdomain_id=torque_data["AirGap"])
     torque_vol = (1 / (mu_0 * (r3 - r2))
-                  * r * (B[0] * ufl.cos(theta) + B[1] * ufl.sin(theta)) * (-B[0] * ufl.sin(theta) + B[1] * ufl.cos(theta))) * dx_gap
+                  * r * (B[0] * ufl.cos(theta) + B[1] * ufl.sin(theta))
+                  * (-B[0] * ufl.sin(theta) + B[1] * ufl.cos(theta))) * dx_gap
 
     # Generate initial electric current in copper windings
     t = 0

--- a/team30_A_phi.py
+++ b/team30_A_phi.py
@@ -342,7 +342,7 @@ def solve_team30(single_phase: bool, T: np.float64, omega_u: np.float64, degree:
         RMS_T_vol = np.sqrt(np.dot(torques_vol, torques_vol) / len(times))
         print(f"RMS Torque: {RMS_T}")
         print(f"RMS Torque Vol: {RMS_T_vol}")
-        plt.savefig(f"results/torque_{omega_u}.png")
+        plt.savefig(f"results/torque_{omega_u}_{ext}.png")
 
 
 if __name__ == "__main__":

--- a/team30_A_phi.py
+++ b/team30_A_phi.py
@@ -16,17 +16,17 @@ freq = 60  # Frequency of excitation
 omega_J = 2 * np.pi * freq
 J = 3.1e6  # [A/m^2] Current density of copper winding
 
-_mu_r = {"Cu": 1, "Strator": 30, "Rotor": 30, "Al": 1, "Air": 1}
-_sigma = {"Rotor": 1.6e6, "Al": 3.72e7, "Strator": 0, "Cu": 0, "Air": 0}
+_mu_r = {"Cu": 1, "Stator": 30, "Rotor": 30, "Al": 1, "Air": 1}
+_sigma = {"Rotor": 1.6e6, "Al": 3.72e7, "Stator": 0, "Cu": 0, "Air": 0}
 
 # Single phase model domains:
 # Copper (0 degrees): 1
 # Copper (180 degrees): 2
-# Steel strator: 3
+# Steel Stator: 3
 # Steel rotor: 4
 # Air: 5, 6, 8, 9, 10
 # Alu rotor: 8
-_domains_single = {"Cu": (1, 2), "Strator": (3,), "Rotor": (4,),
+_domains_single = {"Cu": (1, 2), "Stator": (3,), "Rotor": (4,),
                    "Al": (7,), "Air": (5, 6, 8, 9, 10)}
 # Currents on the form J_0 = (0,0, alpha*J*cos(omega*t + beta)) in domain i
 _currents_single = {1: {"alpha": 1, "beta": 0}, 2: {"alpha": -1, "beta": 0}}
@@ -38,11 +38,11 @@ _surfaces_single = {"MidAir": (11,), "restriction": "+"}
 # Copper (180 degrees): 4
 # Copper (240 degrees): 5
 # Copper (300 degrees): 6
-# Steel strator: 7
+# Steel Stator: 7
 # Steel rotor: 8
 # Air: 9, 10, 12, 13, 14, 15, 16, 17, 18
 # Alu rotor: 11
-_domains_three = {"Cu": (1, 2, 3, 4, 5, 6), "Strator": (7,), "Rotor": (8,),
+_domains_three = {"Cu": (1, 2, 3, 4, 5, 6), "Stator": (7,), "Rotor": (8,),
                   "Al": (10,), "Air": (9, 11, 12, 13, 14, 15, 16, 17, 18)}
 _surfaces_three = {"MidAir": (19,), "restriction": "+"}
 # Currents on the form J_0 = (0,0, alpha*J*cos(omega*t + beta)) in domain i
@@ -154,7 +154,7 @@ def solve_team30(single_phase: bool, T: np.float64, omega_u: np.float64, degree:
     J0z = dolfinx.Function(DG0)  # Current density
 
     # Create integration sets
-    Omega_n = domains["Cu"] + domains["Strator"] + domains["Air"]
+    Omega_n = domains["Cu"] + domains["Stator"] + domains["Air"]
     Omega_c = domains["Rotor"] + domains["Al"]
 
     # Create integration measures
@@ -317,7 +317,7 @@ def solve_team30(single_phase: bool, T: np.float64, omega_u: np.float64, degree:
         # Write solution to file
         postproc.write_function(AzV.sub(0).collapse(), t, "Az")
         postproc.write_function(AzV.sub(1).collapse(), t, "V")
-        # postproc.write_function(J0z, t, "J0z")
+        postproc.write_function(J0z, t, "J0z")
         postproc.write_function(B, t, "B")
     postproc.close()
 
@@ -342,7 +342,7 @@ if __name__ == "__main__":
     _three.add_argument('--three', dest='three', action='store_true',
                         help="Solve three phase problem", default=False)
     parser.add_argument("--T", dest='T', type=np.float64, default=0.025, help="End time of simulation")
-    parser.add_argument("--omega", dest='omegaU', type=np.float64, default=1200, help="Angular speed of rotor")
+    parser.add_argument("--omega", dest='omegaU', type=np.float64, default=0, help="Angular speed of rotor")
     parser.add_argument("--degree", dest='degree', type=np.int32, default=1,
                         help="Degree of magnetic vector potential functions space")
     args = parser.parse_args()


### PR DESCRIPTION
- Add some post processing variables:
  - the magnetic field `B=curl(A)`
  -  the electromagnetic torque measured in the air gap between rotor and windings.
- Replace PETSc insert for DG with `u.x.array[...]`
- Typo fixes
- Cleanup of `ufl.Measure` usage
- Use `PETScOptions` to set solver options