### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/time-domain.yml
+++ b/.github/workflows/time-domain.yml
@@ -10,9 +10,9 @@ on:
     - cron: "0 1 * * *"
 jobs:
   build:
-    if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
-    runs-on: ubuntu-22.04
-    container: ghcr.io/fenics/dolfinx/dolfinx:v0.6.0-r1
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    container: ghcr.io/fenics/dolfinx/dolfinx:nightly
     steps:
       - uses: actions/checkout@v3
     
@@ -23,8 +23,7 @@ jobs:
         run: python3 -m mypy .
 
       - name: Install dependencies
-        run: |
-          pip3 install -r requirements.txt --user
+        run: python3 -m pip install -r requirements.txt --user
 
       - name: Run test
         run: |

--- a/generate_team30_meshes.py
+++ b/generate_team30_meshes.py
@@ -222,7 +222,7 @@ def generate_team30_mesh(filename: Path, single: bool, res: np.float64, L: np.fl
         # gmsh.option.setNumber("Mesh.Algorithm", 7)
         gmsh.option.setNumber("General.Terminal", 1)
         gmsh.model.mesh.generate(gdim)
-        gmsh.write(filename.with_suffix(".msh"))
+        gmsh.write(str(filename.with_suffix(".msh")))
     MPI.COMM_WORLD.Barrier()
     gmsh.finalize()
 

--- a/generate_team30_meshes.py
+++ b/generate_team30_meshes.py
@@ -220,9 +220,9 @@ def generate_team30_mesh(filename: Path, single: bool, res: np.float64, L: np.fl
         gmsh.model.mesh.field.setAsBackgroundMesh(3)
 
         # gmsh.option.setNumber("Mesh.Algorithm", 7)
-        gmsh.option.setNumber("General.Terminal", 0)
+        gmsh.option.setNumber("General.Terminal", 1)
         gmsh.model.mesh.generate(gdim)
-        gmsh.write(f"{filename}.msh")
+        gmsh.write(filename.with_suffix(".msh"))
     MPI.COMM_WORLD.Barrier()
     gmsh.finalize()
 

--- a/generate_team30_meshes_3D.py
+++ b/generate_team30_meshes_3D.py
@@ -269,10 +269,10 @@ if __name__ == "__main__":
             str(fname.with_suffix(".msh")), MPI.COMM_WORLD, 0)
         cell_markers.name = "Cell_markers"
         facet_markers.name = "Facet_markers"
-        with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname.with_suffix(".xdmf"), "w") as xdmf:
+        with dolfinx.io.XDMFFile(mesh.comm, fname.with_suffix(".xdmf"), "w") as xdmf:
             xdmf.write_mesh(mesh)
-            xdmf.write_meshtags(cell_markers)
-            xdmf.write_meshtags(facet_markers)
+            xdmf.write_meshtags(cell_markers, mesh.geometry)
+            xdmf.write_meshtags(facet_markers, mesh.geometry)
     if three:
         fname = folder / "three_phase3D"
         generate_team30_mesh(fname, False, res, L, depth)
@@ -280,7 +280,7 @@ if __name__ == "__main__":
             str(fname.with_suffix(".msh")), MPI.COMM_WORLD, 0)
         cell_markers.name = "Cell_markers"
         facet_markers.name = "Facet_markers"
-        with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname.with_suffix(".xdmf"), "w") as xdmf:
+        with dolfinx.io.XDMFFile(mesh.comm, fname.with_suffix(".xdmf"), "w") as xdmf:
             xdmf.write_mesh(mesh)
-            xdmf.write_meshtags(cell_markers)
-            xdmf.write_meshtags(facet_markers)
+            xdmf.write_meshtags(cell_markers, mesh.geoemtry)
+            xdmf.write_meshtags(facet_markers, mesh.geometry)

--- a/generate_team30_meshes_3D.py
+++ b/generate_team30_meshes_3D.py
@@ -282,5 +282,5 @@ if __name__ == "__main__":
         facet_markers.name = "Facet_markers"
         with dolfinx.io.XDMFFile(mesh.comm, fname.with_suffix(".xdmf"), "w") as xdmf:
             xdmf.write_mesh(mesh)
-            xdmf.write_meshtags(cell_markers, mesh.geoemtry)
+            xdmf.write_meshtags(cell_markers, mesh.geometry)
             xdmf.write_meshtags(facet_markers, mesh.geometry)

--- a/team30_A_phi.py
+++ b/team30_A_phi.py
@@ -236,8 +236,8 @@ def solve_team30(single_phase: bool, num_phases: int, omega_u: np.float64, degre
     post_B.B.name = "B"
     # Create output file
     if save_output:
-        Az_vtx = VTXWriter(mesh.comm, outdir / "Az.bp", [Az_out])
-        B_vtx = VTXWriter(mesh.comm, outdir / "B.bp", [post_B.B])
+        Az_vtx = VTXWriter(mesh.comm, str(outdir / "Az.bp"), [Az_out])
+        B_vtx = VTXWriter(mesh.comm, str(outdir / "B.bp"), [post_B.B])
 
     # Computations needed for adding addiitonal torque to engine
     x = ufl.SpatialCoordinate(mesh)

--- a/test_team30.py
+++ b/test_team30.py
@@ -40,10 +40,10 @@ def test_team30(single_phase, degree):
         str(fname.with_suffix(".msh")), MPI.COMM_WORLD, 0, gdim=2)
     cell_markers.name = "Cell_markers"
     facet_markers.name = "Facet_markers"
-    with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname.with_suffix(".xdmf"), "w") as xdmf:
+    with dolfinx.io.XDMFFile(mesh.comm, fname.with_suffix(".xdmf"), "w") as xdmf:
         xdmf.write_mesh(mesh)
-        xdmf.write_meshtags(cell_markers)
-        xdmf.write_meshtags(facet_markers)
+        xdmf.write_meshtags(cell_markers, mesh.geometry)
+        xdmf.write_meshtags(facet_markers, mesh.geometry)
 
     # Open output file on rank 0
     output = None

--- a/utils.py
+++ b/utils.py
@@ -229,8 +229,8 @@ class MagneticField2D():
 
         # Create dolfinx Expression for electromagnetic field B (post processing)
         # Use minimum DG 1 as VTXFile only supports CG/DG>=1
-        el_B = basix.ufl.element("DG", cell.cellname(), 
-                                 max(degree-1, 1),
+        el_B = basix.ufl.element("DG", cell.cellname(),
+                                 max(degree - 1, 1),
                                  shape=(mesh.geometry.dim,),
                                  gdim=mesh.geometry.dim)
         VB = fem.FunctionSpace(mesh, el_B)

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,11 @@
-# Copyright (C) 2021-2022 Jørgen S. Dokken and Igor A. Baratta
+# Copyright (C) 2021-2023 Jørgen S. Dokken and Igor A. Baratta
 #
 # SPDX-License-Identifier:    MIT
 
 from typing import Dict, Tuple
 
 import numpy as np
+import basix.ufl
 import ufl
 from dolfinx import fem
 from dolfinx import cpp
@@ -223,12 +224,15 @@ class MagneticField2D():
             Takes priority over all other parameter values.
         """
         degree = AzV.function_space.ufl_element().degree()
-        cell = AzV.function_space.ufl_cell()
         mesh = AzV.function_space.mesh
+        cell = mesh.ufl_cell()
 
         # Create dolfinx Expression for electromagnetic field B (post processing)
         # Use minimum DG 1 as VTXFile only supports CG/DG>=1
-        el_B = ufl.VectorElement("DG", cell, max(degree - 1, 1))
+        el_B = basix.ufl.element("DG", cell.cellname(), 
+                                 max(degree-1, 1),
+                                 shape=(mesh.geometry.dim,),
+                                 gdim=mesh.geometry.dim)
         VB = fem.FunctionSpace(mesh, el_B)
         self.B = fem.Function(VB)
         B_2D = ufl.as_vector((AzV[0].dx(1), -AzV[0].dx(0)))


### PR DESCRIPTION
Mostly changes related to the `IO` API.
- `VTXWriter` now supports multiple float types and is wrapped in Python.
- `XDMFFile.write_meshtags` requires the mesh geometry.

Other changes:
- Use `basix.ufl.element` to avoid warnings regarding deprecation of `ufl.*Element`
- `dolfinx.fem.petsc` requires explicit import
- Update CI
  - Remove skip logic as it is naturally supported: https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
  - Run against dolfinx/nightly
  - Add timeout parameter
